### PR TITLE
ramips: Add support for IODATA WN-G300DGR

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -414,6 +414,9 @@ wrh-300cr)
 wndr3700v5)
 	ucidef_set_led_default "power" "POWER" "$board:green:power" "0"
 	;;
+wn-g300dgr)
+	ucidef_set_led_default "power" "POWER" "$board:blue:power" "1"
+	;;
 wt3020-4M|\
 wt3020-8M)
 	ucidef_set_led_default "power" "power" "wt3020:blue:power" "0"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -148,7 +148,8 @@ ramips_setup_interfaces()
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
 	rt-n15|\
-	wl-351)
+	wl-351|\
+	wn-g300dgr)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5@eth0"
 		;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -148,10 +148,13 @@ ramips_setup_interfaces()
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
 	rt-n15|\
-	wl-351|\
-	wn-g300dgr)
+	wl-351)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5@eth0"
+		;;
+	wn-g300dgr)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:wan" "5@eth0"
 		;;
 	asl26555-8M|\
 	asl26555-16M|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -133,6 +133,7 @@ get_status_led() {
 	wl-330n|\
 	wl-330n3g|\
 	wli-tx4-ag300n|\
+	wn-g300dgr|\
 	y1|\
 	y1s|\
 	youku-yk1)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -616,6 +616,9 @@ ramips_board_detect() {
 	*"WMR-300")
 		name="wmr-300"
 		;;
+	*"WN-G300DGR")
+		name="wn-g300dgr"
+		;;
 	*"WN3000RPv3")
 		name="wn3000rpv3"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -174,6 +174,7 @@ platform_check_image() {
 	wlr-6000|\
 	wmdr-143n|\
 	wmr-300|\
+	wn-g300dgr|\
 	wn3000rpv3|\
 	wnce2001|\
 	wndr3700v5|\

--- a/target/linux/ramips/dts/WN-G300DGR.dts
+++ b/target/linux/ramips/dts/WN-G300DGR.dts
@@ -41,44 +41,6 @@
 		};
 	};
 
-	gpio-leds {
-		compatible = "gpio-leds";
-
-		power {
-			label = "wl-351:amber:power";
-			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
-		};
-
-		unpopulated {
-			label = "wl-351:amber:unpopulated";
-			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
-		};
-
-		unpopulated2 {
-			label = "wl-351:blue:unpopulated";
-			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	gpio-keys-polled {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		reset {
-			label = "reset";
-			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		wps {
-			label = "wps";
-			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-	};
-
 	rtl8366rb {
 		compatible = "realtek,rtl8366rb";
 		gpio-sda = <&gpio0 1 GPIO_ACTIVE_HIGH>;

--- a/target/linux/ramips/dts/WN-G300DGR.dts
+++ b/target/linux/ramips/dts/WN-G300DGR.dts
@@ -87,6 +87,20 @@
 			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
+
+		router {
+			label = "router";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		ap {
+			label = "ap";
+			gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
 	};
 
 	rtl8366rb {

--- a/target/linux/ramips/dts/WN-G300DGR.dts
+++ b/target/linux/ramips/dts/WN-G300DGR.dts
@@ -41,6 +41,35 @@
 		};
 	};
 
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power-amber {
+			label = "wn-g300dgr:amber:power";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		power-blue {
+			label = "wn-g300dgr:blue:power";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wps-blue {
+			label = "wn-g300dgr:blue:wps";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wps-green {
+			label = "wn-g300dgr:green:wps";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		filtering {
+			label = "wn-g300dgr:blue:filtering";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
 	rtl8366rb {
 		compatible = "realtek,rtl8366rb";
 		gpio-sda = <&gpio0 1 GPIO_ACTIVE_HIGH>;

--- a/target/linux/ramips/dts/WN-G300DGR.dts
+++ b/target/linux/ramips/dts/WN-G300DGR.dts
@@ -1,0 +1,125 @@
+/dts-v1/;
+
+#include "rt3050.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iodata,wn-g300dgr", "ralink,rt3052-soc";
+	model = "IO-DATA WN-G300DGR";
+
+	cfi@1f000000 {
+		compatible = "cfi-flash";
+		reg = <0x1f000000 0x800000>;
+		bank-width = <2>;
+		device-width = <2>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x3b0000>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "wl-351:amber:power";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		unpopulated {
+			label = "wl-351:amber:unpopulated";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		unpopulated2 {
+			label = "wl-351:blue:unpopulated";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	rtl8366rb {
+		compatible = "realtek,rtl8366rb";
+		gpio-sda = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "spi", "i2c", "jtag", "mdio", "uartf";
+			ralink,function = "gpio";
+		};
+		rgmii {
+			ralink,group = "rgmii";
+			ralink,function = "rgmii";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&esw {
+	ralink,rgmii = <1>;
+	mediatek,portmap = <0x3f>;
+	ralink,fct2 = <0x0002500c>;
+	/*
+	 * ext phy base addr 31, rx/tx clock skew 0,
+	 * turbo mii off, rgmi 3.3v off, port 5 polling off
+	 * port5: enabled, gige, full-duplex, rx/tx-flow-control
+	 * port6: enabled, gige, full-duplex, rx/tx-flow-control
+	*/
+	ralink,fpa2 = <0x1f003fff>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&otg {
+	status = "okay";
+};

--- a/target/linux/ramips/dts/WN-G300DGR.dts
+++ b/target/linux/ramips/dts/WN-G300DGR.dts
@@ -94,13 +94,6 @@
 			linux,code = <BTN_0>;
 			linux,input-type = <EV_SW>;
 		};
-
-		ap {
-			label = "ap";
-			gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
-			linux,code = <BTN_0>;
-			linux,input-type = <EV_SW>;
-		};
 	};
 
 	rtl8366rb {

--- a/target/linux/ramips/dts/WN-G300DGR.dts
+++ b/target/linux/ramips/dts/WN-G300DGR.dts
@@ -7,7 +7,7 @@
 
 / {
 	compatible = "iodata,wn-g300dgr", "ralink,rt3052-soc";
-	model = "IO-DATA WN-G300DGR";
+	model = "IODATA WN-G300DGR";
 
 	cfi@1f000000 {
 		compatible = "cfi-flash";

--- a/target/linux/ramips/dts/WN-G300DGR.dts
+++ b/target/linux/ramips/dts/WN-G300DGR.dts
@@ -70,6 +70,25 @@
 		};
 	};
 
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
 	rtl8366rb {
 		compatible = "realtek,rtl8366rb";
 		gpio-sda = <&gpio0 1 GPIO_ACTIVE_HIGH>;

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -791,7 +791,7 @@ define Device/wn-g300dgr
   IMAGE_SIZE := $(ralink_default_fw_size_4M)
   DEVICE_TITLE := IODATA WN-G300DGR
   DEVICE_PACKAGES := kmod-switch-rtl8366rb kmod-swconfig swconfig \
-    kmod-usb-core kmod-usb-dwc2 kmod-usb2 kmod-usb-ohci
+    kmod-usb-core kmod-usb-dwc2
 endef
 TARGET_DEVICES += wn-g300dgr
 

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -789,7 +789,7 @@ define Device/wn-g300dgr
   DTS := WN-G300DGR
   BLOCKSIZE := 64k
   IMAGE_SIZE := $(ralink_default_fw_size_4M)
-  DEVICE_TITLE := IO-DATA WN-G300DGR
+  DEVICE_TITLE := IODATA WN-G300DGR
   DEVICE_PACKAGES := kmod-switch-rtl8366rb kmod-swconfig swconfig \
     kmod-usb-core kmod-usb-dwc2 kmod-usb2 kmod-usb-ohci
 endef

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -791,7 +791,7 @@ define Device/wn-g300dgr
   IMAGE_SIZE := $(ralink_default_fw_size_4M)
   DEVICE_TITLE := IO-DATA WN-G300DGR
   DEVICE_PACKAGES := kmod-switch-rtl8366rb kmod-swconfig swconfig \
-    kmod-usb-core kmod-usb-dwc2
+    kmod-usb-core kmod-usb-dwc2 kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += wn-g300dgr
 

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -785,6 +785,15 @@ define Device/wl-351
 endef
 TARGET_DEVICES += wl-351
 
+define Device/wn-g300dgr
+  DTS := WN-G300DGR
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  DEVICE_TITLE := IO-DATA WN-G300DGR
+  DEVICE_PACKAGES := kmod-switch-rtl8366rb kmod-swconfig swconfig
+endef
+TARGET_DEVICES += wn-g300dgr
+
 define Device/wnce2001
   DTS := WNCE2001
   IMAGE_SIZE := $(ralink_default_fw_size_4M)

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -790,7 +790,8 @@ define Device/wn-g300dgr
   BLOCKSIZE := 64k
   IMAGE_SIZE := $(ralink_default_fw_size_4M)
   DEVICE_TITLE := IO-DATA WN-G300DGR
-  DEVICE_PACKAGES := kmod-switch-rtl8366rb kmod-swconfig swconfig
+  DEVICE_PACKAGES := kmod-switch-rtl8366rb kmod-swconfig swconfig \
+    kmod-usb-core kmod-usb-dwc2
 endef
 TARGET_DEVICES += wn-g300dgr
 


### PR DESCRIPTION
- SoC: Ralink RT3052F
- RAM: 32MB
- Flash: 4MB
- Switch: Realtek RTL8366RB
- LEDs
  - amber: power
  - blue: power
  - blue: wps
  - green: wps
  - blue: filtering
  - green: wireless
    - operated by wireless controller
- buttons
  - wps
  - reset
  - router
- USB
  - packages added, but cannot recognize connected devices.